### PR TITLE
Add m2e eclipse settings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -245,6 +245,7 @@
         <version.license.header.groupid>org.eclipse.che.dev</version.license.header.groupid>
         <version.license.header.version>${version.resource-bundle}</version.license.header.version>
         <version.license.plugin>1.8</version.license.plugin>
+        <version.m2e.plugin>1.0.0</version.m2e.plugin>
         <version.mycila-license.plugin>2.10</version.mycila-license.plugin>
         <version.plexus-utils>3.0.18</version.plexus-utils>
         <version.plexus.plugin>1.3.8</version.plexus.plugin>
@@ -861,6 +862,151 @@
                             <svg>XML_STYLE</svg>
                             <ts>SLASHSTAR_STYLE</ts>
                         </mapping>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.eclipse.m2e</groupId>
+                    <artifactId>lifecycle-mapping</artifactId>
+                    <version>${version.m2e.plugin}</version>
+                    <configuration>
+                        <lifecycleMappingMetadata>
+                            <pluginExecutions>
+                                <pluginExecution>
+                                    <pluginExecutionFilter>
+                                        <groupId>com.mycila</groupId>
+                                        <artifactId>license-maven-plugin</artifactId>
+                                        <versionRange>[${version.license.plugin},)</versionRange>
+                                        <goals>
+                                            <goal>check</goal>
+                                        </goals>
+                                    </pluginExecutionFilter>
+                                    <action>
+                                        <ignore />
+                                    </action>
+                                </pluginExecution>
+                                <pluginExecution>
+                                    <pluginExecutionFilter>
+                                        <groupId>org.apache.maven.plugins</groupId>
+                                        <artifactId>maven-compiler-plugin</artifactId>
+                                        <versionRange>[${version.compiler.plugin},)</versionRange>
+                                        <goals>
+                                            <goal>compile</goal>
+                                            <goal>testCompile</goal>
+                                        </goals>
+                                        <parameters>
+                                            <compilerId>javac-with-errorprone</compilerId>
+                                        </parameters>
+                                    </pluginExecutionFilter>
+                                    <action>
+                                        <configurator>
+                                            <id>org.eclipse.m2e.jdt.javaConfigurator</id>
+                                        </configurator>
+                                    </action>
+                                </pluginExecution>
+                                <pluginExecution>
+                                    <pluginExecutionFilter>
+                                        <groupId>org.apache.maven.plugins</groupId>
+                                        <artifactId>maven-dependency-plugin</artifactId>
+                                        <versionRange>[${version.dependency.plugin},)</versionRange>
+                                        <goals>
+                                            <goal>unpack-dependencies</goal>
+                                            <goal>copy-dependencies</goal>
+                                            <goal>copy</goal>
+                                        </goals>
+                                    </pluginExecutionFilter>
+                                    <action>
+                                        <ignore />
+                                    </action>
+                                </pluginExecution>
+                                <pluginExecution>
+                                    <pluginExecutionFilter>
+                                        <groupId>com.google.code.sortpom</groupId>
+                                        <artifactId>maven-sortpom-plugin</artifactId>
+                                        <versionRange>[${version.sortpom.plugin},)</versionRange>
+                                        <goals>
+                                            <goal>verify</goal>
+                                        </goals>
+                                    </pluginExecutionFilter>
+                                    <action>
+                                        <execute>
+                                            <runOnConfiguration>true</runOnConfiguration>
+                                            <runOnIncremental>false</runOnIncremental>
+                                        </execute>
+                                    </action>
+                                </pluginExecution>
+                                <pluginExecution>
+                                    <pluginExecutionFilter>
+                                        <groupId>org.apache.maven.plugins</groupId>
+                                        <artifactId>maven-antrun-plugin</artifactId>
+                                        <versionRange>[${version.antrun.plugin},)</versionRange>
+                                        <goals>
+                                            <goal>run</goal>
+                                        </goals>
+                                    </pluginExecutionFilter>
+                                    <action>
+                                        <ignore />
+                                    </action>
+                                </pluginExecution>
+                                <pluginExecution>
+                                    <pluginExecutionFilter>
+                                        <groupId>org.apache.maven.plugins</groupId>
+                                        <artifactId>maven-patch-plugin</artifactId>
+                                        <versionRange>[1.1.1,)</versionRange>
+                                        <goals>
+                                            <goal>apply</goal>
+                                        </goals>
+                                    </pluginExecutionFilter>
+                                    <action>
+                                        <ignore />
+                                    </action>
+                                </pluginExecution>
+                                <pluginExecution>
+                                    <pluginExecutionFilter>
+                                        <groupId>org.codehaus.mojo</groupId>
+                                        <artifactId>exec-maven-plugin</artifactId>
+                                        <versionRange>[${version.exec.plugin},)</versionRange>
+                                        <goals>
+                                            <goal>java</goal>
+                                        </goals>
+                                    </pluginExecutionFilter>
+                                    <action>
+                                        <execute>
+                                            <runOnConfiguration>true</runOnConfiguration>
+                                            <runOnIncremental>false</runOnIncremental>
+                                        </execute>
+                                    </action>
+                                </pluginExecution>
+                                <pluginExecution>
+                                    <pluginExecutionFilter>
+                                        <groupId>org.codehaus.mojo</groupId>
+                                        <artifactId>wagon-maven-plugin</artifactId>
+                                        <versionRange>[1.0-beta-4,)</versionRange>
+                                        <goals>
+                                            <goal>download-single</goal>
+                                        </goals>
+                                    </pluginExecutionFilter>
+                                    <action>
+                                        <ignore />
+                                    </action>
+                                </pluginExecution>
+                                <pluginExecution>
+                                    <pluginExecutionFilter>
+                                        <groupId>org.eclipse.che.core</groupId>
+                                        <artifactId>che-core-api-dto-maven-plugin</artifactId>
+                                        <versionRange>[4,)</versionRange>
+                                        <goals>
+                                            <goal>generate</goal>
+                                        </goals>
+                                    </pluginExecutionFilter>
+                                    <action>
+                                        <execute>
+                                            <runOnConfiguration>true</runOnConfiguration>
+                                            <runOnIncremental>false</runOnIncremental>
+                                        </execute>
+                                    </action>
+                                </pluginExecution>
+                            </pluginExecutions>
+                        </lifecycleMappingMetadata>
                     </configuration>
                 </plugin>
                 <plugin>


### PR DESCRIPTION
so people importing Eclipse Che into Eclipse IDE won't get any errors

Note: no cq for the m2e plugin as it's an eclipse project
also it doesn't imply any changes on the maven build process