### PR TITLE
Move errorprone definition into a profile (enabled by default)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -315,7 +315,7 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>${version.compiler.plugin}</version>
                     <configuration>
-                      <forceJavacCompilerUse>true</forceJavacCompilerUse>
+                        <forceJavacCompilerUse>true</forceJavacCompilerUse>
                     </configuration>
                 </plugin>
                 <plugin>
@@ -1333,44 +1333,6 @@
             </build>
         </profile>
         <profile>
-            <id>errorprone</id>
-            <activation>
-                <property>
-                    <name>!skip-errorprone</name>
-                </property>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-compiler-plugin</artifactId>
-                        <version>${version.compiler.plugin}</version>
-                        <dependencies>
-                            <!-- override plexus-compiler-javac-errorprone's dependency on
-                             Error Prone with the latest version -->
-                            <dependency>
-                                <groupId>com.google.errorprone</groupId>
-                                <artifactId>error_prone_core</artifactId>
-                                <version>${com.google.errorprone}</version>
-                            </dependency>
-                            <dependency>
-                                <groupId>org.codehaus.plexus</groupId>
-                                <artifactId>plexus-compiler-javac-errorprone</artifactId>
-                                <version>2.5</version>
-                            </dependency>
-                        </dependencies>
-                        <configuration>
-                            <compilerArgs>
-                                <arg>-Xep:DepAnn:WARN</arg>
-                            </compilerArgs>
-                            <compilerId>javac-with-errorprone</compilerId>
-                            <forceJavacCompilerUse>true</forceJavacCompilerUse>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <profile>
             <id>enforce</id>
             <activation>
                 <property>
@@ -1691,6 +1653,32 @@
             </activation>
             <build>
                 <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <version>${version.compiler.plugin}</version>
+                        <dependencies>
+                            <!-- override plexus-compiler-javac-errorprone's dependency on
+                             Error Prone with the latest version -->
+                            <dependency>
+                                <groupId>com.google.errorprone</groupId>
+                                <artifactId>error_prone_core</artifactId>
+                                <version>${com.google.errorprone}</version>
+                            </dependency>
+                            <dependency>
+                                <groupId>org.codehaus.plexus</groupId>
+                                <artifactId>plexus-compiler-javac-errorprone</artifactId>
+                                <version>2.5</version>
+                            </dependency>
+                        </dependencies>
+                        <configuration>
+                            <compilerArgs>
+                                <arg>-Xep:DepAnn:WARN</arg>
+                            </compilerArgs>
+                            <compilerId>javac-with-errorprone</compilerId>
+                            <forceJavacCompilerUse>true</forceJavacCompilerUse>
+                        </configuration>
+                    </plugin>
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>findbugs-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -311,6 +311,14 @@
             <!-- All plugins ordered by shortname (antrun, assembly ...) -->
             <plugins>
                 <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>${version.compiler.plugin}</version>
+                    <configuration>
+                      <forceJavacCompilerUse>true</forceJavacCompilerUse>
+                    </configuration>
+                </plugin>
+                <plugin>
                     <groupId>com.jayway.maven.plugins.android.generation2</groupId>
                     <artifactId>android-maven-plugin</artifactId>
                     <version>${version.android.plugin}</version>
@@ -392,32 +400,6 @@
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>clirr-maven-plugin</artifactId>
                     <version>${version.clirr.plugin}</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-compiler-plugin</artifactId>
-                    <version>${version.compiler.plugin}</version>
-                    <dependencies>
-                        <!-- override plexus-compiler-javac-errorprone's dependency on
-                             Error Prone with the latest version -->
-                        <dependency>
-                            <groupId>com.google.errorprone</groupId>
-                            <artifactId>error_prone_core</artifactId>
-                            <version>${com.google.errorprone}</version>
-                        </dependency>
-                        <dependency>
-                            <groupId>org.codehaus.plexus</groupId>
-                            <artifactId>plexus-compiler-javac-errorprone</artifactId>
-                            <version>2.5</version>
-                        </dependency>
-                    </dependencies>
-                    <configuration>
-                        <compilerArgs>
-                            <arg>-Xep:DepAnn:WARN</arg>
-                        </compilerArgs>
-                        <compilerId>javac-with-errorprone</compilerId>
-                        <forceJavacCompilerUse>true</forceJavacCompilerUse>
-                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>com.github.goldin</groupId>
@@ -1346,6 +1328,44 @@
                                 </goals>
                             </execution>
                         </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>errorprone</id>
+            <activation>
+                <property>
+                    <name>!skip-errorprone</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <version>${version.compiler.plugin}</version>
+                        <dependencies>
+                            <!-- override plexus-compiler-javac-errorprone's dependency on
+                             Error Prone with the latest version -->
+                            <dependency>
+                                <groupId>com.google.errorprone</groupId>
+                                <artifactId>error_prone_core</artifactId>
+                                <version>${com.google.errorprone}</version>
+                            </dependency>
+                            <dependency>
+                                <groupId>org.codehaus.plexus</groupId>
+                                <artifactId>plexus-compiler-javac-errorprone</artifactId>
+                                <version>2.5</version>
+                            </dependency>
+                        </dependencies>
+                        <configuration>
+                            <compilerArgs>
+                                <arg>-Xep:DepAnn:WARN</arg>
+                            </compilerArgs>
+                            <compilerId>javac-with-errorprone</compilerId>
+                            <forceJavacCompilerUse>true</forceJavacCompilerUse>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>


### PR DESCRIPTION
For now, we have some "checking tools" that can be disabled through some options
(skip-enforce, skip-validate-sources, etc)
It will allow to disable the errorprone plugin through a flag `-Dskip-errorprone` or `-Dskip-errorprone=true`