### PR TITLE
Add license format for go files

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -843,6 +843,7 @@
                         <mapping>
                             <svg>XML_STYLE</svg>
                             <ts>SLASHSTAR_STYLE</ts>
+                            <go>DOUBLESLASH_STYLE</go>
                         </mapping>
                     </configuration>
                 </plugin>


### PR DESCRIPTION
Adds double slash style for go files.

So the file header looks like the following:

```go
//
// Copyright (c) 2012-2016 Codenvy, S.A.
// All rights reserved. This program and the accompanying materials
// are made available under the terms of the Eclipse Public License v1.0
// which accompanies this distribution, and is available at
// http://www.eclipse.org/legal/epl-v10.html
//
// Contributors:
//   Codenvy, S.A. - initial API and implementation
//

package rpc
```

@skabashnyuk please review