### PR TITLE
Changes in maven parent to adapt  Google java codestyle

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -834,13 +834,11 @@
                             <exclude>**/tomcat-users.xml</exclude>
                             <exclude>**/rewrite.config</exclude>
                         </excludes>
-                        <headerDefinitions>
-                            <headerDefinition>javadoc.xml</headerDefinition>
-                        </headerDefinitions>
                         <mapping>
                             <svg>XML_STYLE</svg>
                             <ts>SLASHSTAR_STYLE</ts>
                             <go>DOUBLESLASH_STYLE</go>
+                            <java>SLASHSTAR_STYLE</java>
                         </mapping>
                     </configuration>
                 </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -215,6 +215,7 @@
         <version.fabric8io.docker.plugin>0.15.16</version.fabric8io.docker.plugin>
         <version.failsafe.plugin>${version.surefire.plugin}</version.failsafe.plugin>
         <version.findbugs.plugin>3.0.1</version.findbugs.plugin>
+        <version.fmt.plugin>1.8.0</version.fmt.plugin>
         <version.gmaven.plugin>1.5</version.gmaven.plugin>
         <version.gmavenplus.plugin>1.2</version.gmavenplus.plugin>
         <version.gpg.plugin>1.6</version.gpg.plugin>
@@ -1065,6 +1066,11 @@
                     </configuration>
                 </plugin>
                 <plugin>
+                    <groupId>com.coveo</groupId>
+                    <artifactId>fmt-maven-plugin</artifactId>
+                    <version>${version.fmt.plugin}</version>
+                </plugin>
+                <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-source-plugin</artifactId>
                     <version>${version.source.plugin}</version>
@@ -1707,6 +1713,18 @@
                                 <phase>validate</phase>
                                 <goals>
                                     <goal>verify</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>com.coveo</groupId>
+                        <artifactId>fmt-maven-plugin</artifactId>
+                        <version>${version.fmt.plugin}</version>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>check</goal>
                                 </goals>
                             </execution>
                         </executions>


### PR DESCRIPTION
### What does this PR do?
1. Configured fmt-maven-plugin to check Google java codestyle. 
2. Changed license to make it compatible with fmt-maven-plugin
now it's 
```
/*
 * Copyright (c) {DATE} {INITIAL COPYRIGHT OWNER} {OTHER COPYRIGHT OWNERS}.
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0
 * which accompanies this distribution, and is available at
 * http://www.eclipse.org/legal/epl-v10.html
 *
 * Contributors:
 *    {INITIAL AUTHOR} - initial API and implementation and/or initial documentation
 */
```

Changes approved by ```Mike Milinkovich```



CQ for plugin https://dev.eclipse.org/ipzilla/show_bug.cgi?id=13960
### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/5772