### PR TITLE
Changed copyright owner to "Red Hat, Inc." in license headers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -22,8 +22,8 @@
     <url>${site.url}</url>
     <inceptionYear>2012</inceptionYear>
     <organization>
-        <name>Codenvy, S.A.</name>
-        <url>http://www.codenvy.com</url>
+        <name>Red Hat, Inc.</name>
+        <url>http://www.redhat.com</url>
     </organization>
     <licenses>
         <license>


### PR DESCRIPTION
### What does this PR do?
Set contributor in license headers to "Red Hat, Inc."

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/5891

#### Changelog
<!-- one line entry to be added to changelog -->
Changed copyright owner to "Red Hat, Inc." in license headers

Please review [Che's Contributing Guide](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md) for best practices.

### Tests written?
No

### Docs updated?
No