### PR TITLE
Remove findbugs from default build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1686,26 +1686,6 @@
                         </configuration>
                     </plugin>
                     <plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>findbugs-maven-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <goals>
-                                    <goal>check</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                        <configuration>
-                            <maxHeap>1024</maxHeap>
-                            <effort>Max</effort>
-                            <threshold>Low</threshold>
-                            <xmlOutput>true</xmlOutput>
-                            <failOnError>${findbugs.failonerror}</failOnError>
-                            <excludeFilterFile>${findbugs.excludeFilterFile}</excludeFilterFile>
-                            <findbugsXmlOutputDirectory>${project.build.directory}/findbugs</findbugsXmlOutputDirectory>
-                        </configuration>
-                    </plugin>
-                    <plugin>
                         <groupId>com.google.code.sortpom</groupId>
                         <artifactId>maven-sortpom-plugin</artifactId>
                         <executions>


### PR DESCRIPTION
### What does this PR do?
Remove findugs check from default build

### What issues does this PR fix or reference?
Fixes https://github.com/eclipse/che/issues/5774
### Previous behavior
findbugs check in default build uses a huge amount of time. 

### New behavior
Since we have no goal to fix all finbugs issues, from now on running finbugs check is totally up to developers.

