### PR TITLE
Upgrade errorprone static check version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <animal-sniffer.signature.groupId>org.codehaus.mojo.signature</animal-sniffer.signature.groupId>
         <animal-sniffer.signature.version>1.0</animal-sniffer.signature.version>
         <archiveClasses>false</archiveClasses>
-        <com.google.errorprone>2.0.11</com.google.errorprone>
+        <com.google.errorprone>2.0.21</com.google.errorprone>
         <currentYear>2017</currentYear>
         <!--  maven-javadoc-plugin -->
         <detectOfflineLinks>false</detectOfflineLinks>


### PR DESCRIPTION
### What does this PR do?
Upgrade version of error prone http://errorprone.info/ static check tool.
CQ https://dev.eclipse.org/ipzilla/show_bug.cgi?id=13960
Fixes in source code made as part of this pr https://github.com/eclipse/che/pull/6004

