### PR TITLE
Add sisu-guice as an ignored dependency for maven-dependency-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1471,6 +1471,9 @@
                                     <goal>analyze-only</goal>
                                 </goals>
                                 <configuration>
+                                    <ignoredUsedUndeclaredDependencies>
+                                      <ignoredUsedUndeclaredDependency>org.sonatype.sisu:sisu-guice</ignoredUsedUndeclaredDependency>
+                                    </ignoredUsedUndeclaredDependencies>
                                     <failOnWarning>true</failOnWarning>
                                     <ignoreNonCompile>true</ignoreNonCompile>
                                     <outputXML>true</outputXML>


### PR DESCRIPTION

### What does this PR do?

Guice is repackaged inside maven. So when code in a maven plugin is using guice (and use guice as dependency) the classes that are loaded are coming from the internal guice/sisu/maven dependency

Then maven-dependency plugin is complaining that we should use sisu-guice dependency. But we can't as we're using official "guice"
also, adding the dependency to this sisu-guice is then making fail maven due to classloaders issue.

Change-Id: Ida4449d96fefa48b7b54302d49be8475de00d478
Signed-off-by: Florent BENOIT <fbenoit@redhat.com>
