### PR TITLE
Execute fmt plugin in validate phase

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1706,6 +1706,7 @@
                         <version>${version.fmt.plugin}</version>
                         <executions>
                             <execution>
+                                <phase>validate</phase>
                                 <goals>
                                     <goal>check</goal>
                                 </goals>


### PR DESCRIPTION

### What does this PR do?
Execute fmt plugin in the same phase with sortpom and license plugin.  Now it's validate


### What issues does this PR fix or reference?
Fixes https://github.com/eclipse/che/issues/6115
