### PR TITLE
Move Eclipse Che dependency plexus component data version to the parent pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -249,6 +249,7 @@
         <version.m2e.plugin>1.0.0</version.m2e.plugin>
         <version.mycila-license.plugin>2.10</version.mycila-license.plugin>
         <version.plexus-utils>3.0.18</version.plexus-utils>
+        <version.plexus.component.metadata.plugin>1.7.1</version.plexus.component.metadata.plugin>
         <version.plexus.plugin>1.3.8</version.plexus.plugin>
         <version.plugin.plugin>3.4</version.plugin.plugin>
         <version.pmd.plugin>3.4</version.pmd.plugin>
@@ -311,6 +312,11 @@
         <pluginManagement>
             <!-- All plugins ordered by shortname (antrun, assembly ...) -->
             <plugins>
+                <plugin>
+                    <groupId>org.codehaus.plexus</groupId>
+                    <artifactId>plexus-component-metadata</artifactId>
+                    <version>${version.plexus.component.metadata.plugin}</version>
+                </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>


### PR DESCRIPTION
### What does this PR do?
Move eclipse che dependency version to the parent pom
It should not be in pom.xml of che project

https://github.com/eclipse/che/blob/abe3271908ac01b5442a4bb2e46cbacd8b22c48c/plugins/plugin-maven/maven-server/maven-server-impl/pom.xml#L214-L216

Also update the version according to CQ
- [x] https://dev.eclipse.org/ipzilla/show_bug.cgi?id=14222

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/5326

### Previous behavior
version is specified in pom.xml in Eclipse Che which is forbidden

### New behavior
version is specified in the parent pom

### Tests written?
No

### Docs updated?
no

Change-Id: I1d086f86d8d599a004c87cc048dda8202c7890c5
Signed-off-by: Florent BENOIT <fbenoit@redhat.com>

