### PR TITLE
Update java source code formatter plugin version (che6)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -216,7 +216,7 @@
         <version.fabric8io.docker.plugin>0.22.1</version.fabric8io.docker.plugin>
         <version.failsafe.plugin>${version.surefire.plugin}</version.failsafe.plugin>
         <version.findbugs.plugin>3.0.1</version.findbugs.plugin>
-        <version.fmt.plugin>1.8.0</version.fmt.plugin>
+        <version.fmt.plugin>2.0.0</version.fmt.plugin>
         <version.gmaven.plugin>1.5</version.gmaven.plugin>
         <version.gmavenplus.plugin>1.2</version.gmavenplus.plugin>
         <version.gpg.plugin>1.6</version.gpg.plugin>


### PR DESCRIPTION
This is the last remaining plugin that I wanted to be updated. It's a dedicated PR as it is including some formatting changes.

I will send a note on che-dev mailing list if OK.

As a side note, I would apply it on both 5.x and 6.x so it's easier to cherry-pick

### CQs
- [X] https://dev.eclipse.org/ipzilla/show_bug.cgi?id=14222

### What does this PR do?

It includes
 - include 1.4 formatting level of google-format https://github.com/google/google-java-format/releases/tag/google-java-format-1.4
 - include display of invalid files (I've provided a pull request https://github.com/coveo/fmt-maven-plugin/pull/17)
 - add threadSafe flag (Provided as well as part of pull request) so there is no warning when you run the build with parallel flags.

example of mvn output
```shell
[ERROR] Found 1 non-complying files, failing build
[ERROR] Non complying file: ..../wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/environment/server/DefaultServicesStartStrategy.java
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
```

### What issues does this PR fix or reference?
N/A

### Tests written?
No

### Docs updated?
N/A

Change-Id: I41fe26c746a395be8001d9dddc673e4b49769f69
Signed-off-by: Florent BENOIT <fbenoit@redhat.com>

