### PR TITLE
move maven build extensions...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -293,23 +293,6 @@
         </pluginRepository>
     </pluginRepositories>
     <build>
-        <extensions>
-            <extension>
-                <groupId>org.apache.maven.wagon</groupId>
-                <artifactId>wagon-webdav-jackrabbit</artifactId>
-                <version>${version.wagon}</version>
-            </extension>
-            <extension>
-                <groupId>org.apache.maven.wagon</groupId>
-                <artifactId>wagon-file</artifactId>
-                <version>${version.wagon}</version>
-            </extension>
-            <extension>
-                <groupId>org.apache.maven.wagon</groupId>
-                <artifactId>wagon-http</artifactId>
-                <version>${version.wagon}</version>
-            </extension>
-        </extensions>
         <pluginManagement>
             <!-- All plugins ordered by shortname (antrun, assembly ...) -->
             <plugins>
@@ -1325,6 +1308,34 @@
         </plugins>
     </reporting>
     <profiles>
+        <profile>
+            <id>extensions</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+                <property>
+                    <name>!no-extensions</name>
+                </property>
+            </activation>
+            <build>
+                <extensions>
+                    <extension>
+                        <groupId>org.apache.maven.wagon</groupId>
+                        <artifactId>wagon-webdav-jackrabbit</artifactId>
+                        <version>${version.wagon}</version>
+                    </extension>
+                    <extension>
+                        <groupId>org.apache.maven.wagon</groupId>
+                        <artifactId>wagon-file</artifactId>
+                        <version>${version.wagon}</version>
+                    </extension>
+                    <extension>
+                        <groupId>org.apache.maven.wagon</groupId>
+                        <artifactId>wagon-http</artifactId>
+                        <version>${version.wagon}</version>
+                    </extension>
+                </extensions>
+            </build>
+        </profile>
         <profile>
             <id>sign-jars</id>
             <build>


### PR DESCRIPTION
move maven build extensions (apache.maven.wagon for webdav, file, and http) to a separate profile so we can disable them when building in Mead/Brew

Change-Id: I7917ac811c5ed8462db43df8eb59d1a45754b361
Signed-off-by: nickboldt <nboldt@redhat.com>