### PR TITLE
Used tag version of che-dev independent from che-parent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1028,6 +1028,7 @@
                     <version>${version.selenium.plugin}</version>
                 </plugin>
                 <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-site-plugin</artifactId>
                     <version>${version.site.plugin}</version>
                     <configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -260,7 +260,7 @@
         <version.release.plugin>2.5.3</version.release.plugin>
         <version.remote-resources.plugin.version>1.5</version.remote-resources.plugin.version>
         <version.replacer.plugin>1.5.3</version.replacer.plugin>
-        <version.resource-bundle>15</version.resource-bundle>
+        <version.resource-bundle>16</version.resource-bundle>
         <version.resources.plugin>3.0.2</version.resources.plugin>
         <version.selenium.plugin>2.3</version.selenium.plugin>
         <version.shade.plugin>2.3</version.shade.plugin>
@@ -1028,9 +1028,12 @@
                     <version>${version.selenium.plugin}</version>
                 </plugin>
                 <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-site-plugin</artifactId>
                     <version>${version.site.plugin}</version>
+                    <configuration>
+                        <skip>true</skip>
+                        <skipDeploy>true</skipDeploy>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
### What does this PR do?
 - Used tag version of che-dev independent from che-parent
 -  Disabled site plugin globally. Since after this https://github.com/eclipse/che-parent/pull/56 it has no ability to upload site's content to http urls. AFAIK we don't use site functionality at all.

### What issues does this PR fix or reference?
Related to https://github.com/eclipse/che/issues/10170
