### PR TITLE
Update lsp4j version to 0.5.0.M1

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -69,7 +69,7 @@
         <joda-time.version>2.3</joda-time.version>
         <log4j.version>1.2.17</log4j.version>
         <logstash.logback.encoder.version>4.11</logstash.logback.encoder.version>
-        <lsp4j.version>0.4.0</lsp4j.version>
+        <lsp4j.version>0.5.0.M1</lsp4j.version>
         <net.java.dev.jna.version>4.1.0</net.java.dev.jna.version>
         <org.antlr.st4.version>4.0.7</org.antlr.st4.version>
         <org.antlr.version>3.5.2</org.antlr.version>


### PR DESCRIPTION
### What does this PR do?
Updates lsp4j to 0.5.0.M1to handle some selenium test failures related to lsp4j marshalling of Either<X, Y> types.

### What issues does this PR fix or reference?
 #10782 