### PR TITLE
use latest release of xtext/xtend 2.14.0; declare dependencies on xtend.lib which are needed by plugin-languageserver/che-plugin-languageserver-ide/pom.xml

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -94,7 +94,7 @@
         <org.eclipse.persistence.version>2.2.0</org.eclipse.persistence.version>
         <org.eclipse.search.version>3.10.0.v20150318-0856</org.eclipse.search.version>
         <org.eclipse.text.version>3.5.101</org.eclipse.text.version>
-        <org.eclipse.xtext.version>2.10.0</org.eclipse.xtext.version>
+        <org.eclipse.xtext.version>2.14.0</org.eclipse.xtext.version>
         <org.everrest.version>1.13.5</org.everrest.version>
         <org.flyway.version>4.2.0</org.flyway.version>
         <org.glassfish.json.version>1.0.4</org.glassfish.json.version>
@@ -1005,6 +1005,16 @@
                 <groupId>org.eclipse.tycho</groupId>
                 <artifactId>org.eclipse.osgi</artifactId>
                 <version>${org.eclipse.osgi.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.xtend</groupId>
+                <artifactId>org.eclipse.xtend.lib</artifactId>
+                <version>${org.eclipse.xtext.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.xtend</groupId>
+                <artifactId>org.eclipse.xtend.lib.macro</artifactId>
+                <version>${org.eclipse.xtext.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.xtext</groupId>


### PR DESCRIPTION
use latest release of xtext/xtend 2.14.0 so we can align on the same version for both

Change-Id: I103f3caac7adf72f25532b304699d8355b042225
Signed-off-by: nickboldt <nboldt@redhat.com>