### PR TITLE
Upgrade dependencies

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -79,7 +79,7 @@
         <net.java.dev.jna.version>4.1.0</net.java.dev.jna.version>
         <org.antlr.st4.version>4.0.7</org.antlr.st4.version>
         <org.antlr.version>3.5.2</org.antlr.version>
-        <org.apache.commons.lang3.version>3.4</org.apache.commons.lang3.version>
+        <org.apache.commons.lang3.version>3.8.1</org.apache.commons.lang3.version>
         <org.apache.lucene.version>7.4.0</org.apache.lucene.version>
         <org.apache.tika.version>1.19.1</org.apache.tika.version>
         <org.apache.tomcat.version>8.5.35</org.apache.tomcat.version>

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -50,7 +50,7 @@
         <com.jcraft.jsch.version>0.1.54</com.jcraft.jsch.version>
         <com.squareup.okhttp3.version>3.9.1</com.squareup.okhttp3.version>
         <commons-codec.version>1.11</commons-codec.version>
-        <commons-compress.version>1.9</commons-compress.version>
+        <commons-compress.version>1.18</commons-compress.version>
         <commons-fileupload.version>1.3.3</commons-fileupload.version>
         <commons-io.version>2.6</commons-io.version>
         <commons-lang.version>2.6</commons-lang.version>

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -38,7 +38,7 @@
         <com.fasterxml.jackson.core.version>2.9.7</com.fasterxml.jackson.core.version>
         <com.google.api-client.version>1.27.0</com.google.api-client.version>
         <com.google.code.guice.version>4.2.2</com.google.code.guice.version>
-        <com.google.guava.version>27.0-jre</com.google.guava.version>
+        <com.google.guava.version>27.0.1-jre</com.google.guava.version>
         <com.google.gwt.gin.version>2.1.2</com.google.gwt.gin.version>
         <com.google.gwt.version>2.8.2</com.google.gwt.version>
         <com.google.http-client.version>1.27.0</com.google.http-client.version>

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -37,7 +37,7 @@
         <com.auth0.jwks-rsa.version>0.3.0</com.auth0.jwks-rsa.version>
         <com.fasterxml.jackson.core.version>2.9.7</com.fasterxml.jackson.core.version>
         <com.google.api-client.version>1.27.0</com.google.api-client.version>
-        <com.google.code.guice.version>4.1.0</com.google.code.guice.version>
+        <com.google.code.guice.version>4.2.2</com.google.code.guice.version>
         <com.google.guava.version>27.0.1-jre</com.google.guava.version>
         <com.google.gwt.gin.version>2.1.2</com.google.gwt.gin.version>
         <com.google.gwt.version>2.8.2</com.google.gwt.version>
@@ -354,11 +354,6 @@
             <dependency>
                 <groupId>com.google.inject.extensions</groupId>
                 <artifactId>guice-assistedinject</artifactId>
-                <version>${com.google.code.guice.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.google.inject.extensions</groupId>
-                <artifactId>guice-multibindings</artifactId>
                 <version>${com.google.code.guice.version}</version>
             </dependency>
             <dependency>

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -35,7 +35,7 @@
         <aopalliance.version>1.0</aopalliance.version>
         <ch.qos.logback.version>1.2.1</ch.qos.logback.version>
         <com.auth0.jwks-rsa.version>0.3.0</com.auth0.jwks-rsa.version>
-        <com.fasterxml.jackson.core.version>2.7.7</com.fasterxml.jackson.core.version>
+        <com.fasterxml.jackson.core.version>2.9.7</com.fasterxml.jackson.core.version>
         <com.google.api-client.version>1.23.0</com.google.api-client.version>
         <com.google.code.guice.version>4.1.0</com.google.code.guice.version>
         <com.google.guava.version>20.0</com.google.guava.version>
@@ -47,12 +47,12 @@
         <com.google.oauth-client.version>1.23.0</com.google.oauth-client.version>
         <com.googlecode.gson.version>2.8.2</com.googlecode.gson.version>
         <com.h2database.version>1.4.196</com.h2database.version>
-        <com.jcraft.jsch.version>0.1.53</com.jcraft.jsch.version>
+        <com.jcraft.jsch.version>0.1.54</com.jcraft.jsch.version>
         <com.squareup.okhttp3.version>3.9.1</com.squareup.okhttp3.version>
-        <commons-codec.version>1.10</commons-codec.version>
+        <commons-codec.version>1.11</commons-codec.version>
         <commons-compress.version>1.9</commons-compress.version>
         <commons-fileupload.version>1.3.3</commons-fileupload.version>
-        <commons-io.version>2.4</commons-io.version>
+        <commons-io.version>2.6</commons-io.version>
         <commons-lang.version>2.6</commons-lang.version>
         <io.fabric8.kubernetes-client>4.1.0</io.fabric8.kubernetes-client>
         <io.fabric8.kubernetes-model>${io.fabric8.kubernetes-client}</io.fabric8.kubernetes-model>
@@ -80,10 +80,10 @@
         <org.antlr.st4.version>4.0.7</org.antlr.st4.version>
         <org.antlr.version>3.5.2</org.antlr.version>
         <org.apache.commons.lang3.version>3.4</org.apache.commons.lang3.version>
-        <org.apache.lucene.version>7.0.1</org.apache.lucene.version>
-        <org.apache.tika.version>1.11</org.apache.tika.version>
-        <org.apache.tomcat.version>8.5.23</org.apache.tomcat.version>
-        <org.bouncycastle.version>1.51</org.bouncycastle.version>
+        <org.apache.lucene.version>7.4.0</org.apache.lucene.version>
+        <org.apache.tika.version>1.19.1</org.apache.tika.version>
+        <org.apache.tomcat.version>8.5.35</org.apache.tomcat.version>
+        <org.bouncycastle.version>1.60</org.bouncycastle.version>
         <org.eclipse.birt.equinox.common.version>3.6.200.v20130402-1505</org.eclipse.birt.equinox.common.version>
         <org.eclipse.core.commands.version>3.6.0</org.eclipse.core.commands.version>
         <org.eclipse.core.contenttype.version>3.4.200-v20140207-1251</org.eclipse.core.contenttype.version>
@@ -114,7 +114,7 @@
         <org.seleniumhq.selenium.version>3.0.1</org.seleniumhq.selenium.version>
         <org.slf4j.version>1.7.24</org.slf4j.version>
         <org.vectomatic.lib-gwt-svg.version>0.5.12</org.vectomatic.lib-gwt-svg.version>
-        <org.yaml.snakeyaml.version>1.14</org.yaml.snakeyaml.version>
+        <org.yaml.snakeyaml.version>1.15</org.yaml.snakeyaml.version>
         <requirejs.upstream.version>2.1.15</requirejs.upstream.version>
         <?SORTPOM IGNORE?>
         <!-- compile time dependencies-->
@@ -199,12 +199,6 @@
                 <groupId>com.fasterxml.jackson.dataformat</groupId>
                 <artifactId>jackson-dataformat-yaml</artifactId>
                 <version>${com.fasterxml.jackson.core.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <artifactId>snakeyaml</artifactId>
-                        <groupId>org.yaml</groupId>
-                    </exclusion>
-                </exclusions>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.datatype</groupId>

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -37,7 +37,7 @@
         <com.auth0.jwks-rsa.version>0.3.0</com.auth0.jwks-rsa.version>
         <com.fasterxml.jackson.core.version>2.9.7</com.fasterxml.jackson.core.version>
         <com.google.api-client.version>1.27.0</com.google.api-client.version>
-        <com.google.code.guice.version>4.2.2</com.google.code.guice.version>
+        <com.google.code.guice.version>4.1.0</com.google.code.guice.version>
         <com.google.guava.version>27.0.1-jre</com.google.guava.version>
         <com.google.gwt.gin.version>2.1.2</com.google.gwt.gin.version>
         <com.google.gwt.version>2.8.2</com.google.gwt.version>
@@ -353,6 +353,11 @@
             <dependency>
                 <groupId>com.google.inject.extensions</groupId>
                 <artifactId>guice-assistedinject</artifactId>
+                <version>${com.google.code.guice.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.inject.extensions</groupId>
+                <artifactId>guice-multibindings</artifactId>
                 <version>${com.google.code.guice.version}</version>
             </dependency>
             <dependency>

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -36,16 +36,16 @@
         <ch.qos.logback.version>1.2.1</ch.qos.logback.version>
         <com.auth0.jwks-rsa.version>0.3.0</com.auth0.jwks-rsa.version>
         <com.fasterxml.jackson.core.version>2.9.7</com.fasterxml.jackson.core.version>
-        <com.google.api-client.version>1.23.0</com.google.api-client.version>
-        <com.google.code.guice.version>4.1.0</com.google.code.guice.version>
-        <com.google.guava.version>20.0</com.google.guava.version>
+        <com.google.api-client.version>1.27.0</com.google.api-client.version>
+        <com.google.code.guice.version>4.2.2</com.google.code.guice.version>
+        <com.google.guava.version>27.0-jre</com.google.guava.version>
         <com.google.gwt.gin.version>2.1.2</com.google.gwt.gin.version>
         <com.google.gwt.version>2.8.2</com.google.gwt.version>
-        <com.google.http-client.version>1.23.0</com.google.http-client.version>
+        <com.google.http-client.version>1.27.0</com.google.http-client.version>
         <com.google.jsinterop.base.version>1.0.0-RC1</com.google.jsinterop.base.version>
         <com.google.jsinterop.version>1.0.2</com.google.jsinterop.version>
-        <com.google.oauth-client.version>1.23.0</com.google.oauth-client.version>
-        <com.googlecode.gson.version>2.8.2</com.googlecode.gson.version>
+        <com.google.oauth-client.version>1.27.0</com.google.oauth-client.version>
+        <com.googlecode.gson.version>2.8.5</com.googlecode.gson.version>
         <com.h2database.version>1.4.196</com.h2database.version>
         <com.jcraft.jsch.version>0.1.54</com.jcraft.jsch.version>
         <com.squareup.okhttp3.version>3.9.1</com.squareup.okhttp3.version>
@@ -82,7 +82,7 @@
         <org.apache.commons.lang3.version>3.8.1</org.apache.commons.lang3.version>
         <org.apache.lucene.version>7.4.0</org.apache.lucene.version>
         <org.apache.tika.version>1.19.1</org.apache.tika.version>
-        <org.apache.tomcat.version>8.5.35</org.apache.tomcat.version>
+        <org.apache.tomcat.version>8.5.23</org.apache.tomcat.version>
         <org.bouncycastle.version>1.60</org.bouncycastle.version>
         <org.eclipse.birt.equinox.common.version>3.6.200.v20130402-1505</org.eclipse.birt.equinox.common.version>
         <org.eclipse.core.commands.version>3.6.0</org.eclipse.core.commands.version>
@@ -353,11 +353,6 @@
             <dependency>
                 <groupId>com.google.inject.extensions</groupId>
                 <artifactId>guice-assistedinject</artifactId>
-                <version>${com.google.code.guice.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.google.inject.extensions</groupId>
-                <artifactId>guice-multibindings</artifactId>
                 <version>${com.google.code.guice.version}</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
### What does this PR do?
Upgrade following dependencies:
com.fasterxml.jackson.core:jackson-annotations 2.7.7 -> 2.9.7
com.fasterxml.jackson.core:jackson-core  2.7.7 -> 2.9.7
com.fasterxml.jackson.core:jackson-databind 2.7.7 -> 2.9.7
com.fasterxml.jackson.dataformat:jackson-dataformat-yaml 2.7.7 -> 2.9.7
com.fasterxml.jackson.datatype:jackson-datatype-joda 2.7.7 -> 2.9.7
com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider 2.7.7 -> 2.9.7
org.apache.tika:tika-core 1.11 -> 1.19.1
org.bouncycastle:bcpkix-jdk15on 1.51 -> 1.60
org.bouncycastle:bcprov-jdk15on 1.51 -> 1.60
org.yaml:snakeyaml 1.14 -> 1.15
com.jcraft:jsch 0.1.53 -> 0.1.54
commons-codec:commons-codec 1.10 -> 1.11
commons-io:commons-io 2.4 -> 2.6
org.apache.commons:commons-lang3 3.4 -> 3.8.1
commons-compress 1.9 -> 1.18

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/11902

CQs (Type A)


- [x] https://dev.eclipse.org/ipzilla/show_bug.cgi?id=18190 Jackson Annotations
- [x] https://dev.eclipse.org/ipzilla/show_bug.cgi?id=18191 Jackson Core
- [x] https://dev.eclipse.org/ipzilla/show_bug.cgi?id=18194 Jackson Databind
- [x] https://dev.eclipse.org/ipzilla/show_bug.cgi?id=18235 Jackson JAX-RS
- [x] https://dev.eclipse.org/ipzilla/show_bug.cgi?id=18236 Jackson datatype Joda
- [x] https://dev.eclipse.org/ipzilla/show_bug.cgi?id=18237 Jackson datatformat YAML
- [x] https://dev.eclipse.org/ipzilla/show_bug.cgi?id=18195 Jsch
- [x] https://dev.eclipse.org/ipzilla/show_bug.cgi?id=18196 Snakeyaml
- [x] https://dev.eclipse.org/ipzilla/show_bug.cgi?id=18197 Commons IO
- [x] https://dev.eclipse.org/ipzilla/show_bug.cgi?id=18317 Commons codec
- [x] https://dev.eclipse.org/ipzilla/show_bug.cgi?id=18201 bcprov-jdk15on 
- [x] https://dev.eclipse.org/ipzilla/show_bug.cgi?id=18202 bcpkix-jdk15on
- [x] https://dev.eclipse.org/ipzilla/show_bug.cgi?id=18203 Apache Tika core
- [x] https://dev.eclipse.org/ipzilla/show_bug.cgi?id=18249 Commons Lang
- [x] https://dev.eclipse.org/ipzilla/show_bug.cgi?id=18281 Guice
- [x] https://dev.eclipse.org/ipzilla/show_bug.cgi?id=18285 Guice persist
- [x] https://dev.eclipse.org/ipzilla/show_bug.cgi?id=18286 Guice assistedinject
- [x] https://dev.eclipse.org/ipzilla/show_bug.cgi?id=18290 Guice servlet
- [x] https://dev.eclipse.org/ipzilla/show_bug.cgi?id=18306 Google OAuth client
- [x] https://dev.eclipse.org/ipzilla/show_bug.cgi?id=18311 Google API client
- [x] https://dev.eclipse.org/ipzilla/show_bug.cgi?id=18307 Google API client Jackson 2 extension
- [x] https://dev.eclipse.org/ipzilla/show_bug.cgi?id=18310 GSON
- [x] https://dev.eclipse.org/ipzilla/show_bug.cgi?id=18308 Guava
- [x] https://dev.eclipse.org/ipzilla/show_bug.cgi?id=18309 Guava-GWT
- [x] https://dev.eclipse.org/ipzilla/show_bug.cgi?id=18329 commons-compress