### PR TITLE
Provide license years using license-maven-plugin-git extension

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -269,7 +269,7 @@
         <version.release.plugin>2.5.3</version.release.plugin>
         <version.remote-resources.plugin.version>1.5</version.remote-resources.plugin.version>
         <version.replacer.plugin>1.5.3</version.replacer.plugin>
-        <version.resource-bundle>19</version.resource-bundle>
+        <version.resource-bundle>20-SNAPSHOT</version.resource-bundle>
         <version.resources.plugin>3.0.2</version.resources.plugin>
         <version.selenium.plugin>2.3</version.selenium.plugin>
         <version.shade.plugin>2.3</version.shade.plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -121,7 +121,6 @@
         <license_contributor2 />
         <license_copyrightOwner>${project.organization.name}</license_copyrightOwner>
         <license_header>license-header.txt</license_header>
-        <license_years>${project.inceptionYear}-${currentYear}</license_years>
         <maven-model.version>3.0.5</maven-model.version>
         <!-- Additional properties to activate the compression of already compressed archives - time expensive -->
         <maven.assembly.recompressZippedFiles>false</maven.assembly.recompressZippedFiles>
@@ -710,6 +709,11 @@
                             <artifactId>${version.license.header.artifactid}</artifactId>
                             <version>${version.license.header.version}</version>
                         </dependency>
+                        <dependency>
+                            <groupId>com.mycila</groupId>
+                            <artifactId>license-maven-plugin-git</artifactId>
+                            <version>${version.mycila-license.plugin}</version>
+                        </dependency>
                     </dependencies>
                     <configuration>
                         <header>${license_header}</header>
@@ -718,7 +722,6 @@
                             <h_inceptionYear>${project.inceptionYear}</h_inceptionYear>
                             <h_currentYear>${currentYear}</h_currentYear>
                             <h_copyrightOwner>${license_copyrightOwner}</h_copyrightOwner>
-                            <h_license_years>${license_years}</h_license_years>
                             <h_contributor>${license_contributor}</h_contributor>
                             <h_contributor2>${license_contributor2}</h_contributor2>
                         </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -269,7 +269,7 @@
         <version.release.plugin>2.5.3</version.release.plugin>
         <version.remote-resources.plugin.version>1.5</version.remote-resources.plugin.version>
         <version.replacer.plugin>1.5.3</version.replacer.plugin>
-        <version.resource-bundle>20-SNAPSHOT</version.resource-bundle>
+        <version.resource-bundle>20</version.resource-bundle>
         <version.resources.plugin>3.0.2</version.resources.plugin>
         <version.selenium.plugin>2.3</version.selenium.plugin>
         <version.shade.plugin>2.3</version.shade.plugin>


### PR DESCRIPTION
### What does this PR do?
Enable https://github.com/mycila/license-maven-plugin/tree/master/license-maven-plugin-git that changes the process of determining license years in headers:

- previously it was ${project.inceptionYear} - ${currentYear}, both these values would be determined in parent. Eventually i new year, last year would be upgraded in all files
- now it will be ${project.inceptionYear} - ${license.git.copyrightLastYear}, where latter is being determined for each file with header, based on the year of last commited changes to the file, commited or uncommited 

 Must be merged with https://github.com/eclipse/che-dev/pull/16



