### PR TITLE
Update Apache maven surefire plug-in to be compliant with Java11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -278,7 +278,7 @@
         <version.sonar-maven-report.plugin>0.1</version.sonar-maven-report.plugin>
         <version.sortpom.plugin>2.3.0</version.sortpom.plugin>
         <version.source.plugin>3.0.1</version.source.plugin>
-        <version.surefire.plugin>2.20.1</version.surefire.plugin>
+        <version.surefire.plugin>2.22.1</version.surefire.plugin>
         <version.taglist.plugin>2.4</version.taglist.plugin>
         <version.tomcat7.plugin>2.2</version.tomcat7.plugin>
         <version.versions.plugin>2.4</version.versions.plugin>


### PR DESCRIPTION
### What does this PR do?
Update surefire plug-in

CQ is covered by https://dev.eclipse.org/ipzilla/show_bug.cgi?id=14222
```
name: maven-surefire-plugin
url: http://maven.apache.org/surefire/maven-surefire-plugin/
license: Apache License 2.0
version: 2.20.1 and later versions
```

### What issues does this PR fix or reference?
fix was tested there https://github.com/eclipse/che/pull/12692 without regressions


Change-Id: Id9c5038dcb85b2ac9c2388e3291223d55dc8ba9b
Signed-off-by: Florent Benoit <fbenoit@redhat.com>

