### PR TITLE
Add tracing-as-metrics dependencies

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -531,6 +531,11 @@
             </dependency>
             <dependency>
                 <groupId>io.jaegertracing</groupId>
+                <artifactId>jaeger-micrometer</artifactId>
+                <version>${io.jaegertracing.micrometer.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.jaegertracing</groupId>
                 <artifactId>jaeger-tracerresolver</artifactId>
                 <version>${io.jaegertracing.version}</version>
             </dependency>
@@ -561,6 +566,16 @@
             </dependency>
             <dependency>
                 <groupId>io.opentracing.contrib</groupId>
+                <artifactId>opentracing-api-extensions</artifactId>
+                <version>${io.opentracing.api.extensions.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.opentracing.contrib</groupId>
+                <artifactId>opentracing-api-extensions-tracer</artifactId>
+                <version>${io.opentracing.api.extensions.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.opentracing.contrib</groupId>
                 <artifactId>opentracing-concurrent</artifactId>
                 <version>${io.opentracing.concurrent.version}</version>
             </dependency>
@@ -568,6 +583,16 @@
                 <groupId>io.opentracing.contrib</groupId>
                 <artifactId>opentracing-jdbc</artifactId>
                 <version>${io.opentracing.jdbc.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.opentracing.contrib</groupId>
+                <artifactId>opentracing-metrics</artifactId>
+                <version>${io.opentracing.contrib.metrics.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.opentracing.contrib</groupId>
+                <artifactId>opentracing-metrics-micrometer</artifactId>
+                <version>${io.opentracing.contrib.metrics.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.opentracing.contrib</groupId>

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -58,9 +58,12 @@
         <io.fabric8.kubernetes-model>${io.fabric8.kubernetes-client}</io.fabric8.kubernetes-model>
         <io.fabric8.openshift-client.version>${io.fabric8.kubernetes-client}</io.fabric8.openshift-client.version>
         <io.github.mweirauc.micrometer-jvm-extras.version>0.1.3</io.github.mweirauc.micrometer-jvm-extras.version>
+        <io.jaegertracing.micrometer.version>0.33.1</io.jaegertracing.micrometer.version>
         <io.jaegertracing.version>0.32.0</io.jaegertracing.version>
         <io.micrometer.version>1.1.0</io.micrometer.version>
+        <io.opentracing.api.extensions.version>0.1.0</io.opentracing.api.extensions.version>
         <io.opentracing.concurrent.version>0.2.0</io.opentracing.concurrent.version>
+        <io.opentracing.contrib.metrics.version>0.3.0</io.opentracing.contrib.metrics.version>
         <io.opentracing.jdbc.version>0.0.9</io.opentracing.jdbc.version>
         <io.opentracing.tracerresolver.version>0.1.5</io.opentracing.tracerresolver.version>
         <io.opentracing.version>0.31.0</io.opentracing.version>


### PR DESCRIPTION
### What does this PR do?
Add dependencies for reporting Jaeger traces as Prometheus metrics
as well as reporting Jaeger internal metrics

Required for https://github.com/eclipse/che/pull/12823/files
### What issues does this PR fix or reference?
https://github.com/eclipse/che/pull/12823

