### PR TITLE
Declared opentracing-noop version

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -561,6 +561,11 @@
             </dependency>
             <dependency>
                 <groupId>io.opentracing</groupId>
+                <artifactId>opentracing-noop</artifactId>
+                <version>${io.opentracing.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.opentracing</groupId>
                 <artifactId>opentracing-util</artifactId>
                 <version>${io.opentracing.version}</version>
             </dependency>


### PR DESCRIPTION
### What does this PR do?
Declared opentracing-noop version
- [x] opentracing-noop https://dev.eclipse.org/ipzilla/show_bug.cgi?id=18093

### What issues does this PR fix or reference?
Need for https://github.com/eclipse/che/pull/12897
