### PR TITLE
Bump micrometer, prometheus and postgresql driver

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -60,7 +60,7 @@
         <io.github.mweirauc.micrometer-jvm-extras.version>0.1.3</io.github.mweirauc.micrometer-jvm-extras.version>
         <io.jaegertracing.micrometer.version>0.33.1</io.jaegertracing.micrometer.version>
         <io.jaegertracing.version>0.32.0</io.jaegertracing.version>
-        <io.micrometer.version>1.1.0</io.micrometer.version>
+        <io.micrometer.version>1.2.1</io.micrometer.version>
         <io.opentracing.api.extensions.version>0.3.0</io.opentracing.api.extensions.version>
         <io.opentracing.concurrent.version>0.2.0</io.opentracing.concurrent.version>
         <io.opentracing.contrib.metrics.version>0.3.0</io.opentracing.contrib.metrics.version>
@@ -68,7 +68,7 @@
         <io.opentracing.tracerresolver.version>0.1.5</io.opentracing.tracerresolver.version>
         <io.opentracing.version>0.31.0</io.opentracing.version>
         <io.opentracing.web-servlet-filter.version>0.2.2</io.opentracing.web-servlet-filter.version>
-        <io.prometheus.simpleclient.version>0.5.0</io.prometheus.simpleclient.version>
+        <io.prometheus.simpleclient.version>0.6.0</io.prometheus.simpleclient.version>
         <io.swagger.version>1.5.9</io.swagger.version>
         <jackson-coreutils.version>1.9</jackson-coreutils.version>
         <javax.annotation.version>1.2</javax.annotation.version>
@@ -123,7 +123,7 @@
         <org.kohsuke.github-api.version>1.90</org.kohsuke.github-api.version>
         <org.latencyutils.version>2.0.3</org.latencyutils.version>
         <org.mod4j.org.eclipse.core.expressions.version>3.4.100</org.mod4j.org.eclipse.core.expressions.version>
-        <org.postgresql.version>9.4-1201-jdbc41</org.postgresql.version>
+        <org.postgresql.version>42.2.2</org.postgresql.version>
         <org.reflections.version>0.9.9</org.reflections.version>
         <org.seleniumhq.selenium.version>3.0.1</org.seleniumhq.selenium.version>
         <org.slf4j.version>1.7.24</org.slf4j.version>


### PR DESCRIPTION
### What does this PR do?
Update prometheus, micrometer & postgresql driver for potential use of db metrics

### What issues does this PR fix or reference?


CQ list (type A):
- [x] http://dev.eclipse.org/ipzilla/show_bug.cgi?id=20812 - prometheus simpleclient
- [x] http://dev.eclipse.org/ipzilla/show_bug.cgi?id=20813 - prometheus simpleclient httpserver
- [x] http://dev.eclipse.org/ipzilla/show_bug.cgi?id=20814 - micrometer core
- [x] http://dev.eclipse.org/ipzilla/show_bug.cgi?id=20815 - micrometer prometheus registry
- [x] https://dev.eclipse.org/ipzilla/show_bug.cgi?id=19594 - postgresql

### Previous behavior
(Remove this section if not relevant)

### New behavior
(Explain the PR as it should appear in the release notes)

Please review [Che's Contributing Guide](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md) for best practices.

### Tests written?
Yes/No

### Docs updated?
Please add a matching PR to [the docs repo](http://github.com/eclipse/che-docs) and link that PR to this issue. Both will be merged at the same time. 
