### PR TITLE
Upgrade tracing and monitoring dependencies

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -61,13 +61,13 @@
         <io.jaegertracing.micrometer.version>1.0.0</io.jaegertracing.micrometer.version>
         <io.jaegertracing.version>1.0.0</io.jaegertracing.version>
         <io.micrometer.version>1.3.0</io.micrometer.version>
-        <io.opentracing.api.extensions.version>0.3.0</io.opentracing.api.extensions.version>
-        <io.opentracing.concurrent.version>0.2.0</io.opentracing.concurrent.version>
+        <io.opentracing.api.extensions.version>0.5.0</io.opentracing.api.extensions.version>
+        <io.opentracing.concurrent.version>0.4.0</io.opentracing.concurrent.version>
         <io.opentracing.contrib.metrics.version>0.3.0</io.opentracing.contrib.metrics.version>
-        <io.opentracing.jdbc.version>0.0.9</io.opentracing.jdbc.version>
-        <io.opentracing.tracerresolver.version>0.1.5</io.opentracing.tracerresolver.version>
-        <io.opentracing.version>0.31.0</io.opentracing.version>
-        <io.opentracing.web-servlet-filter.version>0.2.2</io.opentracing.web-servlet-filter.version>
+        <io.opentracing.jdbc.version>0.1.8</io.opentracing.jdbc.version>
+        <io.opentracing.tracerresolver.version>0.1.8</io.opentracing.tracerresolver.version>
+        <io.opentracing.version>0.33.0</io.opentracing.version>
+        <io.opentracing.web-servlet-filter.version>0.4.0</io.opentracing.web-servlet-filter.version>
         <io.prometheus.simpleclient.version>0.7.0</io.prometheus.simpleclient.version>
         <io.swagger.version>1.5.9</io.swagger.version>
         <jackson-coreutils.version>1.9</jackson-coreutils.version>

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -58,9 +58,9 @@
         <io.fabric8.kubernetes-model>${io.fabric8.kubernetes-client}</io.fabric8.kubernetes-model>
         <io.fabric8.openshift-client.version>${io.fabric8.kubernetes-client}</io.fabric8.openshift-client.version>
         <io.github.mweirauc.micrometer-jvm-extras.version>0.1.3</io.github.mweirauc.micrometer-jvm-extras.version>
-        <io.jaegertracing.micrometer.version>0.33.1</io.jaegertracing.micrometer.version>
-        <io.jaegertracing.version>0.32.0</io.jaegertracing.version>
-        <io.micrometer.version>1.2.1</io.micrometer.version>
+        <io.jaegertracing.micrometer.version>1.0.0</io.jaegertracing.micrometer.version>
+        <io.jaegertracing.version>1.0.0</io.jaegertracing.version>
+        <io.micrometer.version>1.3.0</io.micrometer.version>
         <io.opentracing.api.extensions.version>0.3.0</io.opentracing.api.extensions.version>
         <io.opentracing.concurrent.version>0.2.0</io.opentracing.concurrent.version>
         <io.opentracing.contrib.metrics.version>0.3.0</io.opentracing.contrib.metrics.version>
@@ -68,7 +68,7 @@
         <io.opentracing.tracerresolver.version>0.1.5</io.opentracing.tracerresolver.version>
         <io.opentracing.version>0.31.0</io.opentracing.version>
         <io.opentracing.web-servlet-filter.version>0.2.2</io.opentracing.web-servlet-filter.version>
-        <io.prometheus.simpleclient.version>0.6.0</io.prometheus.simpleclient.version>
+        <io.prometheus.simpleclient.version>0.7.0</io.prometheus.simpleclient.version>
         <io.swagger.version>1.5.9</io.swagger.version>
         <jackson-coreutils.version>1.9</jackson-coreutils.version>
         <javax.annotation.version>1.2</javax.annotation.version>


### PR DESCRIPTION
### What does this PR do?
- [x] jaeger-client-1.0.0.jar https://dev.eclipse.org/ipzilla/show_bug.cgi?id=20906
- [x] jaeger-core-1.0.0.jar https://dev.eclipse.org/ipzilla/show_bug.cgi?id=20907
- [x] jaeger-micrometer-1.0.0.jar https://dev.eclipse.org/ipzilla/show_bug.cgi?id=20908
- [x] jaeger-thrift-1.0.0.jar https://dev.eclipse.org/ipzilla/show_bug.cgi?id=20909
- [x] jaeger-tracerresolver-1.0.0.jar https://dev.eclipse.org/ipzilla/show_bug.cgi?id=20910
- [x] libthrift-0.12.0.jar https://dev.eclipse.org/ipzilla/show_bug.cgi?id=20905
- [x] micrometer-core-1.3.0.jar  https://dev.eclipse.org/ipzilla/show_bug.cgi?id=20911
- [x] micrometer-registry-prometheus-1.3.0.jar https://dev.eclipse.org/ipzilla/show_bug.cgi?id=20912
- [x] opentracing-api-0.33.0.jar https://dev.eclipse.org/ipzilla/show_bug.cgi?id=20944
- [x] opentracing-api-extensions-0.5.0.jar https://dev.eclipse.org/ipzilla/show_bug.cgi?id=20945
- [x] opentracing-api-extensions-tracer-0.5.0.jar https://dev.eclipse.org/ipzilla/show_bug.cgi?id=20946
- [x] opentracing-concurrent-0.4.0.jar https://dev.eclipse.org/ipzilla/show_bug.cgi?id=20947
- [x] opentracing-jdbc-0.1.8.jar https://dev.eclipse.org/ipzilla/show_bug.cgi?id=20948
- [x] opentracing-noop-0.33.0.jar https://dev.eclipse.org/ipzilla/show_bug.cgi?id=20949
- [x] opentracing-tracerresolver-0.1.8.jar https://dev.eclipse.org/ipzilla/show_bug.cgi?id=20950
- [x] opentracing-util-0.33.0.jar https://dev.eclipse.org/ipzilla/show_bug.cgi?id=20951
- [x] opentracing-web-servlet-filter-0.4.0.jar https://dev.eclipse.org/ipzilla/show_bug.cgi?id=20952
- [x] simpleclient-0.7.0.jar  https://dev.eclipse.org/ipzilla/show_bug.cgi?id=20913
- [x] simpleclient_common-0.7.0.jar https://dev.eclipse.org/ipzilla/show_bug.cgi?id=20914
- [x] simpleclient_httpserver-0.7.0.jar https://dev.eclipse.org/ipzilla/show_bug.cgi?id=20915
### What issues does this PR fix or reference?

