### PR TITLE
Backport: Update JGroups to version 4.1.0, EclipseLink to 2.7.5 and KUBE_PING to 1.0.13 

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -107,7 +107,7 @@
         <org.eclipse.jetty.version>9.2.14.v20151106</org.eclipse.jetty.version>
         <org.eclipse.jgit.version>4.9.0.201710071750-r</org.eclipse.jgit.version>
         <org.eclipse.osgi.version>3.10.0.v20140606-1445</org.eclipse.osgi.version>
-        <org.eclipse.persistence.eclipselink.version>2.7.0</org.eclipse.persistence.eclipselink.version>
+        <org.eclipse.persistence.eclipselink.version>2.7.5-RC2</org.eclipse.persistence.eclipselink.version>
         <org.eclipse.persistence.version>2.2.0</org.eclipse.persistence.version>
         <org.eclipse.search.version>3.10.0.v20150318-0856</org.eclipse.search.version>
         <org.eclipse.text.version>3.5.101</org.eclipse.text.version>
@@ -118,8 +118,8 @@
         <org.hdrhistogram.version>2.1.9</org.hdrhistogram.version>
         <org.javassist.version>3.22.0-GA</org.javassist.version>
         <org.jdom.version>1.1.3</org.jdom.version>
-        <org.jgroups.kubernetes.version>0.9.3</org.jgroups.kubernetes.version>
-        <org.jgroups.version>3.6.15.Final</org.jgroups.version>
+        <org.jgroups.kubernetes.version>1.0.13.Final</org.jgroups.kubernetes.version>
+        <org.jgroups.version>4.1.0.Final</org.jgroups.version>
         <org.kohsuke.github-api.version>1.90</org.kohsuke.github-api.version>
         <org.latencyutils.version>2.0.3</org.latencyutils.version>
         <org.mod4j.org.eclipse.core.expressions.version>3.4.100</org.mod4j.org.eclipse.core.expressions.version>
@@ -1233,7 +1233,7 @@
             </dependency>
             <dependency>
                 <groupId>org.jgroups.kubernetes</groupId>
-                <artifactId>kubernetes</artifactId>
+                <artifactId>jgroups-kubernetes</artifactId>
                 <version>${org.jgroups.kubernetes.version}</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
### What does this PR do?
Update JGroups to version `4.1.0.Final`, EL to `2.7.5-RC2` and KUBE_PING to `1.0.13.Final`

- [x] https://dev.eclipse.org/ipzilla/show_bug.cgi?id=20522
 - [x] https://dev.eclipse.org/ipzilla/show_bug.cgi?id=20984 
### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/13607
