### PR TITLE
Use release version of eclipse persistence

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -107,7 +107,7 @@
         <org.eclipse.jetty.version>9.2.14.v20151106</org.eclipse.jetty.version>
         <org.eclipse.jgit.version>4.9.0.201710071750-r</org.eclipse.jgit.version>
         <org.eclipse.osgi.version>3.10.0.v20140606-1445</org.eclipse.osgi.version>
-        <org.eclipse.persistence.eclipselink.version>2.7.5-RC2</org.eclipse.persistence.eclipselink.version>
+        <org.eclipse.persistence.eclipselink.version>2.7.5</org.eclipse.persistence.eclipselink.version>
         <org.eclipse.persistence.version>2.2.0</org.eclipse.persistence.version>
         <org.eclipse.search.version>3.10.0.v20150318-0856</org.eclipse.search.version>
         <org.eclipse.text.version>3.5.101</org.eclipse.text.version>


### PR DESCRIPTION
### What does this PR do?
Use release version of eclipse persistence  2.7.5  to avoid RC dependency.

### What issues does this PR fix or reference?

### Tests written?
No

### Docs updated?
N/A