### PR TITLE
Upgrade of micrometer to 1.3.1

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -60,7 +60,7 @@
         <io.github.mweirauc.micrometer-jvm-extras.version>0.1.3</io.github.mweirauc.micrometer-jvm-extras.version>
         <io.jaegertracing.micrometer.version>1.0.0</io.jaegertracing.micrometer.version>
         <io.jaegertracing.version>1.0.0</io.jaegertracing.version>
-        <io.micrometer.version>1.3.0</io.micrometer.version>
+        <io.micrometer.version>1.3.1</io.micrometer.version>
         <io.opentracing.api.extensions.version>0.5.0</io.opentracing.api.extensions.version>
         <io.opentracing.concurrent.version>0.4.0</io.opentracing.concurrent.version>
         <io.opentracing.contrib.metrics.version>0.3.0</io.opentracing.contrib.metrics.version>


### PR DESCRIPTION
### What does this PR do?
Upgrade of micrometer to 1.3.1 
Need for https://github.com/eclipse/che/pull/15207
 - [x] micrometer-core 1.3.1 https://dev.eclipse.org/ipzilla/show_bug.cgi?id=21110
 - [x] micrometer-registry-prometheus 1.3.1 https://dev.eclipse.org/ipzilla/show_bug.cgi?id=21111


### What issues does this PR fix or reference?
Fixes https://github.com/micrometer-metrics/micrometer/issues/1667
