### PR TITLE
Update to newest JGroups version due to locking bug

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -119,7 +119,7 @@
         <org.javassist.version>3.22.0-GA</org.javassist.version>
         <org.jdom.version>1.1.3</org.jdom.version>
         <org.jgroups.kubernetes.version>1.0.13.Final</org.jgroups.kubernetes.version>
-        <org.jgroups.version>4.1.0.Final</org.jgroups.version>
+        <org.jgroups.version>4.1.8.Final</org.jgroups.version>
         <org.kohsuke.github-api.version>1.90</org.kohsuke.github-api.version>
         <org.latencyutils.version>2.0.3</org.latencyutils.version>
         <org.mod4j.org.eclipse.core.expressions.version>3.4.100</org.mod4j.org.eclipse.core.expressions.version>


### PR DESCRIPTION
### What does this PR do?
Currently used version seems to having issue with locking (see https://github.com/eclipse/che/issues/15231, jgroups upstream one: https://issues.jboss.org/browse/JGRP-2299) which produces stale threads and brokes underlying functionality like workspaces suspend etc. Need to upgrate to the fixed version.


### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/15231
