### PR TITLE
Temporary solution to prevent failing nightly build job on centos.ci

### DIFF
--- a/.ci/cico_build_nightly.sh
+++ b/.ci/cico_build_nightly.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+#
+# Copyright (c) 2012-2019 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+
+#Temporary solution to prevent failing nightly build job on centos.ci
+exit 0


### PR DESCRIPTION
Signed-off-by: Vitalii Parfonov <vparfono@redhat.com>

### What does this PR do?
add script for nightly builds, at the moment script do nothing 

### What issues does this PR fix or reference?

### Previous behavior
(Remove this section if not relevant)

### New behavior
(Explain the PR as it should appear in the release notes)

Please review [Che's Contributing Guide](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md) for best practices.

### Tests written?
Yes/No

### Docs updated?
Please add a matching PR to [the docs repo](http://github.com/eclipse/che-docs) and link that PR to this issue. Both will be merged at the same time. 
