### PR TITLE
Upgrade Kubernetes client and transitive dependencies

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -35,7 +35,7 @@
         <aopalliance.version>1.0</aopalliance.version>
         <ch.qos.logback.version>1.2.1</ch.qos.logback.version>
         <com.auth0.jwks-rsa.version>0.3.0</com.auth0.jwks-rsa.version>
-        <com.fasterxml.jackson.core.version>2.9.7</com.fasterxml.jackson.core.version>
+        <com.fasterxml.jackson.core.version>2.10.3</com.fasterxml.jackson.core.version>
         <com.google.api-client.version>1.27.0</com.google.api-client.version>
         <com.google.code.guice.version>4.2.2</com.google.code.guice.version>
         <com.google.guava.version>27.0.1-jre</com.google.guava.version>
@@ -48,13 +48,13 @@
         <com.googlecode.gson.version>2.8.5</com.googlecode.gson.version>
         <com.h2database.version>1.4.196</com.h2database.version>
         <com.jcraft.jsch.version>0.1.54</com.jcraft.jsch.version>
-        <com.squareup.okhttp3.version>3.9.1</com.squareup.okhttp3.version>
+        <com.squareup.okhttp3.version>3.12.6</com.squareup.okhttp3.version>
         <commons-codec.version>1.11</commons-codec.version>
         <commons-compress.version>1.18</commons-compress.version>
         <commons-fileupload.version>1.3.3</commons-fileupload.version>
         <commons-io.version>2.6</commons-io.version>
         <commons-lang.version>2.6</commons-lang.version>
-        <io.fabric8.kubernetes-client>4.1.0</io.fabric8.kubernetes-client>
+        <io.fabric8.kubernetes-client>4.9.0</io.fabric8.kubernetes-client>
         <io.fabric8.kubernetes-model>${io.fabric8.kubernetes-client}</io.fabric8.kubernetes-model>
         <io.fabric8.openshift-client.version>${io.fabric8.kubernetes-client}</io.fabric8.openshift-client.version>
         <io.github.mweirauc.micrometer-jvm-extras.version>0.1.3</io.github.mweirauc.micrometer-jvm-extras.version>
@@ -128,7 +128,7 @@
         <org.seleniumhq.selenium.version>3.0.1</org.seleniumhq.selenium.version>
         <org.slf4j.version>1.7.24</org.slf4j.version>
         <org.vectomatic.lib-gwt-svg.version>0.5.12</org.vectomatic.lib-gwt-svg.version>
-        <org.yaml.snakeyaml.version>1.15</org.yaml.snakeyaml.version>
+        <org.yaml.snakeyaml.version>1.24</org.yaml.snakeyaml.version>
         <requirejs.upstream.version>2.1.15</requirejs.upstream.version>
         <?SORTPOM IGNORE?>
         <!-- compile time dependencies-->


### PR DESCRIPTION
### What does this PR do?
Upgrade Kubernetes client and transitive dependencies

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/11981
https://github.com/eclipse/che/pull/16345

# CQs
- [x] jackson-annotations-2.10.3.jar https://dev.eclipse.org/ipzilla/show_bug.cgi?id=21813
- [x] jackson-core-2.10.3.jar https://dev.eclipse.org/ipzilla/show_bug.cgi?id=21814
- [x] jackson-databind-2.10.3.jar https://dev.eclipse.org/ipzilla/show_bug.cgi?id=21815
- [x] jackson-dataformat-yaml-2.10.3.jar https://dev.eclipse.org/ipzilla/show_bug.cgi?id=21816
- [x] jackson-datatype-jsr310-2.10.3.jar https://dev.eclipse.org/ipzilla/show_bug.cgi?id=21817
- [x] kubernetes-client-4.9.0.jar https://dev.eclipse.org/ipzilla/show_bug.cgi?id=21818
- [x] kubernetes-model-4.9.0.jar https://dev.eclipse.org/ipzilla/show_bug.cgi?id=21819
- [x] kubernetes-model-common-4.9.0.jar https://dev.eclipse.org/ipzilla/show_bug.cgi?id=21820
- [x] openshift-client-4.9.0.jar https://dev.eclipse.org/ipzilla/show_bug.cgi?id=21821
- [x] logging-interceptor-3.12.6.jar https://dev.eclipse.org/ipzilla/show_bug.cgi?id=21822
- [x] okhttp-3.12.6.jar https://dev.eclipse.org/ipzilla/show_bug.cgi?id=21812
- [x] okio-1.15.0.jar https://dev.eclipse.org/ipzilla/show_bug.cgi?id=21811
- [x] snakeyaml-1.24.jar https://dev.eclipse.org/ipzilla/show_bug.cgi?id=21810
