### PR TITLE
Avoid using old ASM from enforcer plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -196,7 +196,7 @@
         <!-- *************** -->
         <!-- Others versions -->
         <!-- *************** -->
-        <version.animal-sniffer.enforcer-rule>1.11</version.animal-sniffer.enforcer-rule>
+        <version.animal-sniffer.enforcer-rule>1.18</version.animal-sniffer.enforcer-rule>
         <version.antrun.plugin>1.8</version.antrun.plugin>
         <!-- PAR-155 : Produce project sources package distribution -->
         <version.apache-source-release-assembly-descriptor>1.0.4</version.apache-source-release-assembly-descriptor>


### PR DESCRIPTION
### What does this PR do?
Remove old asm 4.0 library, that causes problems during the build of Che with "codenvy-release" profile, and use latest one.

EDIT: update sniffer enforcer rule to newer version, that would use newest ASM

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/16597
