### PR TITLE
Fixing maven-enforcer-plugin that is failing RequirePluginVersions on che-dashboad repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -219,7 +219,7 @@
         <version.ear.plugin>2.10.1</version.ear.plugin>
         <version.eclipse.plugin>2.9</version.eclipse.plugin>
         <version.ejb.plugin>3.0.0</version.ejb.plugin>
-        <version.enforcer.plugin>3.0.0-M2</version.enforcer.plugin>
+        <version.enforcer.plugin>3.0.0-M3</version.enforcer.plugin>
         <version.exec.plugin>1.6.0</version.exec.plugin>
         <version.fabric8io.docker.plugin>0.22.1</version.fabric8io.docker.plugin>
         <version.failsafe.plugin>${version.surefire.plugin}</version.failsafe.plugin>


### PR DESCRIPTION
### What does this PR do?
Fixing maven-enforcer-plugin that is failing RequirePluginVersions on che-dashboad repository

### What issues does this PR fix or reference?
```
[INFO] 
[INFO] --- maven-enforcer-plugin:3.0.0-M2:enforce (distribution-management-used) @ che-dashboard-war ---
[INFO] 
[INFO] --- maven-enforcer-plugin:3.0.0-M2:enforce (no-distribution-management-at-all) @ che-dashboard-war ---
[INFO] 
[INFO] --- maven-enforcer-plugin:3.0.0-M2:enforce (dependency) @ che-dashboard-war ---
[INFO] 
[INFO] --- maven-enforcer-plugin:3.0.0-M2:enforce (ban-bad-dependencies) @ che-dashboard-war ---
[INFO] 
[INFO] --- maven-enforcer-plugin:3.0.0-M2:enforce (enforce-plugin-versions) @ che-dashboard-war ---
[WARNING] Rule 0: org.apache.maven.plugins.enforcer.RequirePluginVersions failed with message:
Some plugins are missing valid versions:(LATEST RELEASE SNAPSHOT are not allowed )
com.google.code.sortpom:maven-sortpom-plugin. 	The version currently in use is 2.3.0
org.apache.maven.plugins:maven-war-plugin. 	The version currently in use is 3.1.0
org.codehaus.mojo:buildnumber-maven-plugin. 	The version currently in use is 1.3
com.coveo:fmt-maven-plugin. 	The version currently in use is 2.5.1
org.codehaus.mojo:build-helper-maven-plugin. 	The version currently in use is 1.9.1
org.apache.maven.plugins:maven-source-plugin. 	The version currently in use is 3.0.1
org.codehaus.mojo:clirr-maven-plugin. 	The version currently in use is 2.6.1
org.apache.maven.plugins:maven-site-plugin. 	The version currently in use is 3.6
org.apache.maven.plugins:maven-javadoc-plugin. 	The version currently in use is 2.10.2
org.apache.maven.plugins:maven-resources-plugin. 	The version currently in use is 3.0.2
org.apache.maven.plugins:maven-assembly-plugin. 	The version currently in use is 3.1.0
com.mycila:license-maven-plugin. 	The version currently in use is 3.0
org.apache.maven.plugins:maven-gpg-plugin. 	The version currently in use is 1.6
org.apache.maven.plugins:maven-compiler-plugin. 	The version currently in use is 3.8.1
org.apache.maven.plugins:maven-surefire-plugin. 	The version currently in use is 2.22.1
org.apache.maven.plugins:maven-clean-plugin. 	The version currently in use is 3.0.0
```
https://ci.centos.org/job/devtools-che-dashboard-che-build-master/22/consoleFull
See more https://issues.apache.org/jira/browse/MENFORCER-306
