### PR TITLE
Do not use release profile for nighlty snapshot builds

### DIFF
--- a/.ci/cico_common.sh
+++ b/.ci/cico_common.sh
@@ -68,7 +68,7 @@ build_and_deploy_artifacts() {
         echo 'Build Success!'
         echo 'Going to deploy artifacts'
     if [[ $(getCurrentVersion) == "*-SNAPSHOT" ]]; then 
-        scl enable rh-maven33 "mvn clean deploy -DskipStaging=true -Pcodenvy-release -DcreateChecksum=true  -Dgpg.passphrase=$CHE_OSS_SONATYPE_PASSPHRASE"
+        scl enable rh-maven33 "mvn clean deploy -DskipStaging=true -DcreateChecksum=true  -Dgpg.passphrase=$CHE_OSS_SONATYPE_PASSPHRASE"
     else
         scl enable rh-maven33 "mvn clean deploy -Pcodenvy-release -DcreateChecksum=true  -Dgpg.passphrase=$CHE_OSS_SONATYPE_PASSPHRASE"
     fi


### PR DESCRIPTION
### What does this PR do?
Do not use release profile for deploying of snapshot builds (since it now prohibits usage of snapshot versions, and this profile has no use for nightly builds)