### PR TITLE
Remove silent install to be able to diagnose why java 11 is not installed.

### DIFF
--- a/.ci/cico_common.sh
+++ b/.ci/cico_common.sh
@@ -39,9 +39,9 @@ load_mvn_settings_gpg_key() {
 
 install_deps(){
     set +x
-    yum -q -y update
-    yum -q -y install centos-release-scl-rh java-11-openjdk-devel git
-    yum -q -y install rh-maven33
+    yum -y update
+    yum -y install centos-release-scl-rh java-11-openjdk-devel git
+    yum -y install rh-maven33
 }
 
 build_and_deploy_artifacts() {


### PR DESCRIPTION
### What does this PR do?
Remove silent install to be able to diagnose why java 11 is not installed.